### PR TITLE
Actions for nightly release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Tiefsee
+name: Build Tiefsee
 
 on:
   push:
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
- 
     runs-on: windows-latest
- 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -32,3 +30,4 @@ jobs:
       with:
         name: Tiefsee
         path: Tiefsee/Tiefsee.zip
+        if-no-files-found: error

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
  
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
      
     - name: Setup MSBuild Path
       uses: microsoft/setup-msbuild@v1.1
@@ -27,8 +27,19 @@ jobs:
     - name: Build Solution and archive artifacts
       run: msbuild Tiefsee4.sln /t:Tiefsee /p:Configuration=Release /p:Platform="Any CPU" /p:DeleteExistingFiles=True
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+  upload-artifacts:
+    needs: build-local
+    runs-on: windows-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
       with:
-        name: Tiefsee4
-        path: Tiefsee.zip
+        name: Tiefsee
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Tiefsee
+        path: Tiefsee/Tiefsee.zip
+      

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,34 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-local:
+ 
+    runs-on: windows-latest
+ 
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout Code
+     
+    - name: Setup MSBuild Path
+      uses: microsoft/setup-msbuild@v1.1
+       
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.2.0
+     
+    - name: Restore NuGet Packages
+      run: nuget restore Tiefsee4.sln
+ 
+    - name: Build and Publish Web App
+      run: msbuild Tiefsee4.sln /p:Configuration=Debug /p:DeployOnBuild=true /p:OutputPath="$(Build.ArtifactStagingDirectory)\\"
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Tiefsee4
+        path: $(Build.ArtifactStagingDirectory)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: windows-latest
  
     steps:
-    - uses: actions/checkout@v1
-      name: Checkout Code
+    - name: Checkout Code
+      uses: actions/checkout@v1
      
     - name: Setup MSBuild Path
       uses: microsoft/setup-msbuild@v1.1
@@ -24,11 +24,11 @@ jobs:
     - name: Restore NuGet Packages
       run: nuget restore Tiefsee4.sln
  
-    - name: Build and Publish Web App
-      run: msbuild Tiefsee4.sln /p:Configuration=Debug /p:DeployOnBuild=true /p:OutputPath="$(Build.ArtifactStagingDirectory)\\"
+    - name: Build Solution and archive artifacts
+      run: msbuild Tiefsee4.sln /t:Tiefsee /p:Configuration=Release /p:Platform="Any CPU" /p:DeleteExistingFiles=True
 
-    - name: Archive Artifacts
+    - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: Tiefsee4
-        path: $(Build.ArtifactStagingDirectory)
+        path: Tiefsee.zip

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: Tiefsee
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-local:
+  build:
  
     runs-on: windows-latest
  
@@ -27,19 +27,8 @@ jobs:
     - name: Build Solution and archive artifacts
       run: msbuild Tiefsee4.sln /t:Tiefsee /p:Configuration=Release /p:Platform="Any CPU" /p:DeleteExistingFiles=True
 
-  upload-artifacts:
-    needs: build-local
-    runs-on: windows-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: Tiefsee
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Tiefsee
         path: Tiefsee/Tiefsee.zip
-      

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   check:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,16 +1,19 @@
 name: Nightly Release
 
 on:
-  workflow_run:
-    workflows: ["Build Tiefsee"]
-    branches: [master]
-    types:
-      - completed
   schedule:
     - cron: '0 2 * * *'
 
 jobs:
+  check:
+    runs-on: windows-latest
+    steps:
+      - id: nightly-check
+        name: Check for changes since last nightly
+        uses: lukecarr/nightly-check@v0.1.0
   nightly-release:
+    needs: check
+    if: ${{ needs.check.outputs.changes == 'true' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
     types:
       - completed
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   nightly-release:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '10 16 * * *'
 
 jobs:
   check:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,10 +11,10 @@ jobs:
   nightly-release:
     permissions:
       id-token: write
-      contents: read
+      contents: write
       pull-requests: write
       actions: read
-    name: Download artifact
+    name: Create Nightly Release
     runs-on: windows-latest
     steps:
       - name: Download artifact

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - id: nightly-check
         name: Check for changes since last nightly
-        uses: lukecarr/nightly-check@v0.2.0
+        uses: lukecarr/nightly-check@v0.3.0
   nightly-release:
     needs: check
     if: ${{ needs.check.outputs.changes == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,34 @@
+
+name: Nightly Release
+
+on:
+  workflow_run:
+    workflows: ["Build Tiefsee"]
+    branches: [main]
+    types:
+      - completed
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  download-artifact:
+    name: Download artifact
+    runs-on: windows-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Tiefsee
+          path: ./Tiefsee.zip
+
+      - name: Update Nightly Release
+        uses: andelf/nightly-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly
+          name: 'Tiefsee Nightly Release $$'
+          prerelease: true
+          body: 'TODO: Add nightly release notes'
+          files: |
+            ./*.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,11 +2,11 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '10 16 * * *'
+    - cron: '23 16 * * *'
 
 jobs:
   check:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - id: nightly-check
         name: Check for changes since last nightly
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       actions: read
     name: Create Nightly Release
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,8 +7,6 @@ on:
     branches: [main]
     types:
       - completed
-  schedule:
-    - cron: '0 2 * * *'
 
 jobs:
   download-artifact:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,18 +2,10 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '23 16 * * *'
+    - cron: '35 16 * * *'
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - id: nightly-check
-        name: Check for changes since last nightly
-        uses: lukecarr/nightly-check@v0.1.0
   nightly-release:
-    needs: check
-    if: ${{ needs.check.outputs.changes == 'true' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ name: Nightly Release
 on:
   workflow_run:
     workflows: ["Build Tiefsee"]
-    branches: [main]
+    branches: [master]
     types:
       - completed
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,4 +35,4 @@ jobs:
           prerelease: true
           body: 'TODO: Add nightly release notes'
           files: |
-            ./*.zip
+            ./Tiefsee/Tiefsee.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,11 @@ on:
 
 jobs:
   nightly-release:
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      actions: read
     name: Download artifact
     runs-on: windows-latest
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '35 16 * * *'
+    - cron: '00 18 * * *' # GitHub Actions use UTC time
 
 jobs:
   nightly-release:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,3 @@
-
 name: Nightly Release
 
 on:
@@ -9,15 +8,17 @@ on:
       - completed
 
 jobs:
-  download-artifact:
+  nightly-release:
     name: Download artifact
     runs-on: windows-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
-          name: Tiefsee
-          path: ./Tiefsee.zip
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: master
 
       - name: Update Nightly Release
         uses: andelf/nightly-release@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,15 @@ on:
     - cron: '00 18 * * *' # GitHub Actions use UTC time
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - id: nightly-check
+        name: Check for changes since last nightly
+        uses: lukecarr/nightly-check@v0.2.0
   nightly-release:
+    needs: check
+    if: ${{ needs.check.outputs.changes == 'true' }}
     permissions:
       id-token: write
       contents: write

--- a/Tiefsee/Tiefsee.csproj
+++ b/Tiefsee/Tiefsee.csproj
@@ -87,5 +87,12 @@
 		<Content Remove="www\ts\**" />
 		<Content Remove="www\scss\**" />
 	</ItemGroup>
+
+  <!-- Generate zip file after build -->
+  <Target Name="ZipOutputPath" AfterTargets="Build">
+        <ZipDirectory
+            SourceDirectory="$(OutputPath)"
+            DestinationFile="$(MSBuildProjectDirectory)\Tiefsee.zip" />
+  </Target>
 		
 </Project>


### PR DESCRIPTION
## TODO Lists
- [x] Create nightly release
- [x] Check whatever master branch changed before create release
- [x] Include `gulp build` command
- [ ] Make `msbuild` to generate single executable for release
## Feature
Automatically create nightly release #11 
## Description
I've completed the workflow for creating nightly release at 2 AM (UTC+8) (GitHub Actions hosted runner use UTC)
At 2 AM, the workflow will fetch the latest built artefacts and update the nightly release title & content (You can modify the release title and  content in the yml file or just edit release info)

If you want, you can modify when will nightly release will be created (There's an expected delay if you using GitHub shared runner for the build, probably around 3 to 10 minutes)

P.S: The following screenshot date was yesterday from the day I created the pull request cause GitHub Actions use UTC as I mentioned before, I can modify it to use UTC +8 timezone or you can leave it to use UTC instead)

## Screenshot
![image](https://github.com/hbl917070/Tiefsee4/assets/33322926/4dc48196-a9df-449a-ada4-13d1902cc59c)
